### PR TITLE
Remove unused macro and reduntant data structure

### DIFF
--- a/vm.h
+++ b/vm.h
@@ -26,11 +26,6 @@ typedef struct {
     int result;
 } vm_inst;
 
-typedef struct {
-    int opcode;
-    vm_handler handler;
-} vm_opcode_impl;
-
 #define VM_T(_op) _op->type
 #define VM_INT(_op) _op->value.vint
 #define VM_UINT(_op) ((unsigned int) _op->value.vint)


### PR DESCRIPTION
Macro `HANDLER` is unused.
Data structure `vm_opcode_impl`'s member `opcode` is unused.

Remove macro `HANDLER`.
Redefined `vm_opcode_impl` as `vm_handler`.