### PR TITLE
Notation revise for jmp-like instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Implement minimal instruction set and assembler/compiler in order to
 allow the execution of classic Hello World program.
 
+## Notation usage
+
+Use `$` for a instant value, and `#` for a temporary storage
 
 ## Instruction set
 

--- a/tests/coverage.s
+++ b/tests/coverage.s
@@ -1,9 +1,8 @@
-; FIXME: all instructions should be used for coverage test.
 add $40 $2 #1
 add #1 $8 #2
 print #1
 print #2
-jmp #6
+jmp $6
 sub #2 $16 #3		; skipped because previous jump
 add #2 $100 #3		; to be executed
 print #3
@@ -15,11 +14,11 @@ div $4 $2 #6            ; divide: 4 / 2 = 2
 mod $5 $2 #7            ; modulo: 5 % 2 = 1
 print #6
 print #7
-call #19
-jmp #24
+call $19
+jmp $24
 halt
 print $66
-call #22
+call $22
 ret
 print $77
 ret

--- a/tests/jcond.s
+++ b/tests/jcond.s
@@ -1,4 +1,4 @@
-jmp #5                      ; keep pass/fail at fixed location
+jmp $5                      ; keep pass/fail at fixed location
 print "cond_jump_insts_ok"   ; all conditional jump instructions pass this test
 halt
 print "cond_jump_insts_fail"; any fail
@@ -6,30 +6,30 @@ halt
 sub $0 $1 #1                ; operand -1
 add $0 $0 #2                ; operand 0
 add $0 $1 #3                ; operand 1
-jlt #1 #10                  ; jlt should only branch with a negative operand
-jmp #3
-jlt #2 #3
-jlt #3 #3
-jle #1 #14                  ; jle should only branch with a zero or negative operand
-jmp #3
-jle #2 #16
-jmp #3
-jle #3 #3
-jz  #1 #3                   ; jz should only branch with a zero operand
-jz  #2 #20
-jmp #3
-jz  #3 #3
-jge #1 #3                   ; jge should only branch with a zero or positive operand
-jge #2 #24
-jmp #3
-jge #3 #26
-jmp #3
-jgt #1 #3                   ; jgt should only branch with a positive operand
-jgt #2 #3
-jgt #3 #30
-jmp #3
-jnz #1 #32                  ; jnz should only branch with a negative or positive operand
-jmp #3
-jnz #2 #3
-jnz #3 #1
-jmp #3
+jlt #1 $10                  ; jlt should only branch with a negative operand
+jmp $3
+jlt #2 $3
+jlt #3 $3
+jle #1 $14                  ; jle should only branch with a zero or negative operand
+jmp $3
+jle #2 $16
+jmp $3
+jle #3 $3
+jz  #1 $3                   ; jz should only branch with a zero operand
+jz  #2 $20
+jmp $3
+jz  #3 $3
+jge #1 $3                   ; jge should only branch with a zero or positive operand
+jge #2 $24
+jmp $3
+jge #3 $26
+jmp $3
+jgt #1 $3                   ; jgt should only branch with a positive operand
+jgt #2 $3
+jgt #3 $30
+jmp $3
+jnz #1 $32                  ; jnz should only branch with a negative or positive operand
+jmp $3
+jnz #2 $3
+jnz #3 $1
+jmp $3

--- a/vm.c
+++ b/vm.c
@@ -59,7 +59,7 @@ static inline void vm_push(vm_env *env, size_t n);
     do {                                                              \
         int gle = vm_get_op_value(env, &OPCODE.op1)->value.vint;      \
         if (gle cond 0) {                                             \
-            size_t n = vm_get_op_value(env, &OPCODE.op1)->value.vint; \
+            size_t n = vm_get_op_value(env, &OPCODE.op2)->value.vint; \
             GOTO(n);                                                  \
         }                                                             \
         DISPATCH;                                                     \


### PR DESCRIPTION
Revised the `$`,`#` notation in jmp-like instructions. ( `$` for CONST, `#` for TEMP )

Also modified all jmp-like instruction in test/*.s to match revised usage.
